### PR TITLE
Encoding terms to handle url constraints for search

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -11,105 +11,107 @@ using Newtonsoft.Json;
 using System.Linq;
 using McMaster.Extensions.CommandLineUtils;
 using System.ComponentModel.DataAnnotations;
+using System.Web;
 
 namespace ConsoleApplication
 {
-  [HelpOption]
-  [Command(ThrowOnUnexpectedArgument = false)]
-  class Program
-  {
-
-    [Option(Description = "Open first result", LongName = "lucky", ShortName = "l")]
-    public bool Lucky { get; set; } = true;
-
-    [Option(Description = "Output option to console", LongName = "console", ShortName = "c")]
-    public bool Inline { get; set; } = true;
-
-    [Option(Description = "Number of results 1 - 25", LongName = "number", ShortName = "n")]
-    [Range(1, 25)]
-    public int Results { get; set; } = 5;
-
-    [Argument(0)]
-    public string Terms { get; set; }
-
-    public string[] RemainingArguments { get; }
-
-    public static int Main(string[] args)
-        => CommandLineApplication.Execute<Program>(args);
-
-    private void OnExecute(CommandLineApplication app)
+    [HelpOption]
+    [Command(ThrowOnUnexpectedArgument = false)]
+    class Program
     {
-      if (String.IsNullOrEmpty(Terms))
-      {
-        app.ShowHelp();
-      }
-      else
-      {
-        string locale = CultureInfo.CurrentCulture.Name;
-        if (Inline | Lucky)
+
+        [Option(Description = "Open first result", LongName = "lucky", ShortName = "l")]
+        public bool Lucky { get; set; } = true;
+
+        [Option(Description = "Output option to console", LongName = "console", ShortName = "c")]
+        public bool Inline { get; set; } = true;
+
+        [Option(Description = "Number of results 1 - 25", LongName = "number", ShortName = "n")]
+        [Range(1, 25)]
+        public int Results { get; set; } = 5;
+
+        [Argument(0)]
+        public string Terms { get; set; }
+
+        public string[] RemainingArguments { get; }
+
+        public static int Main(string[] args)
+            => CommandLineApplication.Execute<Program>(args);
+
+        private void OnExecute(CommandLineApplication app)
         {
-          string api = $"https://docs.microsoft.com/api/search?search={Terms}&locale={locale}&$top={Results}";
-
-          var items = GetResults(api);
-
-          if (Lucky)
-          {
-            OpenResult(items.Result.results[0].url);
-          }
-
-          if (Inline)
-          {
-            Console.WriteLine("Items found: " + items.Result.count.ToString());
-            foreach (Result r in items.Result.results)
+            if (String.IsNullOrEmpty(Terms))
             {
-              Console.WriteLine(r.iconType);
-              Console.WriteLine(r.title);
-              Console.WriteLine(r.url);
-              Console.WriteLine(" ");
+                app.ShowHelp();
             }
-          }
+            else
+            {
+                string encodedTerms = HttpUtility.HtmlEncode(Terms);
+                string locale = CultureInfo.CurrentCulture.Name;
+                if (Inline | Lucky)
+                {
+                    string api = $"https://docs.microsoft.com/api/search?search={encodedTerms}&locale={locale}&$top={Results}";
+
+                    var items = GetResults(api);
+
+                    if (Lucky)
+                    {
+                        OpenResult(items.Result.results[0].url);
+                    }
+
+                    if (Inline)
+                    {
+                        Console.WriteLine("Items found: " + items.Result.count.ToString());
+                        foreach (Result r in items.Result.results)
+                        {
+                            Console.WriteLine(r.iconType);
+                            Console.WriteLine(r.title);
+                            Console.WriteLine(r.url);
+                            Console.WriteLine(" ");
+                        }
+                    }
+                }
+                else
+                {
+                    string url = $"https://docs.microsoft.com/search/index?search={encodedTerms}";
+                    OpenResult(url);
+                }
+            }
         }
-        else
+
+        private void OpenResult(string url)
         {
-          string url = $"https://docs.microsoft.com/search/index?search={Terms}";
-          OpenResult(url);
+            var cmd = "open";
+
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                cmd = "xdg-open";
+                Process.Start(new ProcessStartInfo(cmd, url));
+            }
+
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                cmd = "open";
+                Process.Start(new ProcessStartInfo(cmd, url));
+            }
+
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Process.Start(Utils.GetDefaultBrowserPath(), url);
+            }
         }
-      }
+
+        public async static Task<Docs> GetResults(string url)
+        {
+            var http = new HttpClient();
+            var response = await http.GetStringAsync(url);
+
+            var data = JsonConvert.DeserializeObject<Docs>(response);
+
+            return data;
+        }
+
     }
-
-    private void OpenResult(string url)
-    {
-      var cmd = "open";
-
-      if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-      {
-        cmd = "xdg-open";
-        Process.Start(new ProcessStartInfo(cmd, url));
-      }
-
-      if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-      {
-        cmd = "open";
-        Process.Start(new ProcessStartInfo(cmd, url));
-      }
-
-      if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-      {
-        Process.Start(Utils.GetDefaultBrowserPath(), url);
-      }
-    }
-
-    public async static Task<Docs> GetResults(string url)
-    {
-      var http = new HttpClient();
-      var response = await http.GetStringAsync(url);
-
-      var data = JsonConvert.DeserializeObject<Docs>(response);
-
-      return data;
-    }
-
-  }
 }
 
 


### PR DESCRIPTION
Right now this call fails

> docs application insights

As it tries to open multiple browsers (windows). It makes sense to HtmlEncode the Terms when building the QS args for the url.